### PR TITLE
Refactor: Configure Vite to bundle dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,16 +46,6 @@
         blink-caret-effect 0.75s step-end infinite;
     }
   </style>
-<script type="importmap">
-{
-  "imports": {
-    "react-dom/": "https://esm.sh/react-dom@^18.2.0/",
-    "react/": "https://esm.sh/react@^18.2.0/",
-    "react": "https://esm.sh/react@^18.2.0",
-    "@google/genai": "https://esm.sh/@google/genai@^1.5.1"
-  }
-}
-</script>
 <!-- <link rel="stylesheet" href="/index.css"> -->
 </head>
 <body class="bg-slate-800 text-white">


### PR DESCRIPTION
I removed the HTML import map that loaded React, ReactDOM, and @google/genai from a CDN. Your project is now configured for Vite to bundle these dependencies directly from node_modules.

This change aims to resolve page loading issues by aligning with standard Vite project structure and dependency handling.

- I removed the import map from `index.html`.
- I verified `tsconfig.json` for appropriate module resolution (`bundler`) and JSX settings (`react-jsx`).
- I confirmed `vite.config.ts` does not externally exclude these dependencies.